### PR TITLE
Fixes for test process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
+  - pip install pytest pytest-cache pytest-benchmark
   - pip install .
-  - pip uninstall -y pytest-isort
 # command to run tests
-script: pytest --pep8 -s
+script: pytest -s

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
 Cython
-pytest
-pytest-cache
-pytest-isort
-pytest-benchmark


### PR DESCRIPTION
Do not use pep8 test in travis tests.

Install pytest an acc. libs. for tests only.